### PR TITLE
Add AI Terminal Agent CLI with sandbox tooling and MERN scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.env
+audit.log
+notes.txt
+client/node_modules
+server/node_modules
+coverage
+.DS_Store

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Terminal Agent</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ai-terminal-agent-client",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.3.1",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.5",
+    "sass": "^1.77.5",
+    "vite": "^5.3.3",
+    "vitest": "^1.6.0"
+  }
+}

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,43 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import Layout from './components/Layout';
+import useContent from './hooks/useContent';
+import styles from './app.styles.scss';
+
+const queryClient = new QueryClient();
+
+const ContentView = () => {
+  const { data } = useContent();
+  if (!data) {
+    return null;
+  }
+  return (
+    <div className={styles.wrapper}>
+      <section className={styles.hero}>
+        <h1>{data.hero.title}</h1>
+        <p className={styles.subtitle}>{data.hero.subtitle}</p>
+        <p>{data.hero.description}</p>
+      </section>
+      <section className={styles.features}>
+        {data.features.map((feature) => (
+          <article key={feature.name} className={styles.featureCard}>
+            <h2>{feature.name}</h2>
+            <p>{feature.details}</p>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+};
+
+const App = () => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Layout>
+        <ContentView />
+      </Layout>
+    </QueryClientProvider>
+  );
+};
+
+export default App;

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import App from './App';
+
+describe('App', () => {
+  it('renders hero content', () => {
+    render(<App />);
+    expect(screen.getByText(/AI Terminal Agent/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/app.styles.scss
+++ b/client/src/app.styles.scss
@@ -1,0 +1,32 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.hero {
+  background: linear-gradient(135deg, #f0f4ff, #ffffff);
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.subtitle {
+  color: #3a3a44;
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.featureCard {
+  padding: 1.5rem;
+  border: 1px solid #e1e4f0;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+
+import styles from './layout.styles.scss';
+
+const Layout = ({ children }) => {
+  return <div className={styles.container}>{children}</div>;
+};
+
+Layout.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export default Layout;

--- a/client/src/components/layout.styles.scss
+++ b/client/src/components/layout.styles.scss
@@ -1,0 +1,7 @@
+.container {
+  margin: 0 auto;
+  padding: 2rem;
+  max-width: 960px;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #1b1b1f;
+}

--- a/client/src/data/content.json
+++ b/client/src/data/content.json
@@ -1,0 +1,21 @@
+{
+  "hero": {
+    "title": "AI Terminal Agent",
+    "subtitle": "Secure, sandboxed automation for developers",
+    "description": "Orchestrate Groq-powered workflows with safe file operations, command execution, and automated self-healing pipelines."
+  },
+  "features": [
+    {
+      "name": "Realtime Coding",
+      "details": "Stream code directly into sandboxed files with live terminal feedback."
+    },
+    {
+      "name": "Testing & Self-Healing",
+      "details": "Automatically run tests and repair failures with iterative retries."
+    },
+    {
+      "name": "Human in the Loop",
+      "details": "Confirm sensitive actions and retain full visibility through audit logs."
+    }
+  ]
+}

--- a/client/src/hooks/useContent.js
+++ b/client/src/hooks/useContent.js
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import content from '../data/content.json';
+
+const fetchContent = async () => content;
+
+const useContent = () => {
+  return useQuery({
+    queryKey: ['content'],
+    queryFn: fetchContent,
+    staleTime: Infinity
+  });
+};
+
+export default useContent;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import App from './App';
+
+const render = () => {
+  const rootElement = document.getElementById('root');
+  if (!rootElement) {
+    return;
+  }
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+};
+
+render();

--- a/client/src/setupTests.js
+++ b/client/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  server: {
+    port: 5173
+  },
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.js'
+  }
+});

--- a/index.js
+++ b/index.js
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const chalk = require('chalk');
+const dotenv = require('dotenv');
+const prompts = require('prompts');
+const ora = require('ora');
+
+const llm = require('./llm');
+const runShell = require('./tools/runShell');
+const readFile = require('./tools/readFile');
+const writeStreamFile = require('./tools/writeStreamFile');
+const testFile = require('./tools/testFile');
+
+dotenv.config();
+
+const SANDBOX_DIR = path.resolve(process.env.SANDBOX_DIR || './sandbox');
+const AUTO_APPROVE = String(process.env.AUTO_APPROVE || 'false').toLowerCase() === 'true';
+const MAX_SELF_HEAL_RETRIES = parseInt(process.env.MAX_SELF_HEAL_RETRIES || '3', 10);
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  prompt: chalk.cyan('AI-Terminal-Agent> ')
+});
+
+const logAudit = async (message) => {
+  const line = `[${new Date().toISOString()}] ${message}\n`;
+  await fs.promises.appendFile(path.resolve('audit.log'), line).catch(() => {});
+};
+
+const ensureSandbox = async () => {
+  await fs.promises.mkdir(SANDBOX_DIR, { recursive: true });
+};
+
+const confirmAction = async (message) => {
+  if (AUTO_APPROVE) {
+    await logAudit(`AUTO_APPROVED: ${message}`);
+    return true;
+  }
+
+  const response = await prompts({
+    type: 'confirm',
+    name: 'value',
+    message,
+    initial: false
+  });
+
+  const granted = Boolean(response.value);
+  await logAudit(`CONFIRM ${granted ? 'YES' : 'NO'}: ${message}`);
+  return granted;
+};
+
+const showHelp = () => {
+  const help = `\n${chalk.bold('AI Terminal Agent Commands')}\n` +
+    `  ${chalk.yellow(':help')} - Show this help message\n` +
+    `  ${chalk.yellow(':exit')} - Exit the CLI\n` +
+    `  ${chalk.yellow(':ls')} [path] - List sandbox contents\n` +
+    `  ${chalk.yellow(':read <file>')} - Read sandbox file\n` +
+    `  ${chalk.yellow(':run <command>')} - Run allowed shell command\n` +
+    `  ${chalk.yellow(':audit')} - Show recent audit entries\n` +
+    `  ${chalk.yellow(':reset')} - Wipe sandbox directory\n` +
+    `  ${chalk.yellow('write <file> :: <prompt>')} - Generate code into file\n` +
+    `  ${chalk.yellow('chat <prompt>')} - Ask the AI a question\n`;
+  console.log(help);
+};
+
+const listSandbox = async (target) => {
+  const safePath = target ? path.resolve(SANDBOX_DIR, target) : SANDBOX_DIR;
+  if (!safePath.startsWith(SANDBOX_DIR)) {
+    console.log(chalk.red('Path outside sandbox is not allowed.'));
+    return;
+  }
+  try {
+    const contents = await fs.promises.readdir(safePath);
+    contents.forEach((item) => console.log(item));
+  } catch (error) {
+    console.log(chalk.red(`Unable to list directory: ${error.message}`));
+  }
+};
+
+const readAudit = async () => {
+  try {
+    const file = await fs.promises.readFile(path.resolve('audit.log'), 'utf8');
+    console.log(file.split('\n').slice(-20).join('\n'));
+  } catch (error) {
+    console.log(chalk.yellow('Audit log is empty.'));
+  }
+};
+
+const resetSandbox = async () => {
+  const confirmed = await confirmAction('This will remove all sandbox files. Continue?');
+  if (!confirmed) {
+    return;
+  }
+
+  try {
+    const entries = await fs.promises.readdir(SANDBOX_DIR);
+    await Promise.all(entries.map(async (entry) => {
+      const target = path.join(SANDBOX_DIR, entry);
+      await fs.promises.rm(target, { recursive: true, force: true });
+    }));
+    await logAudit('Sandbox reset.');
+    console.log(chalk.green('Sandbox cleared.'));
+  } catch (error) {
+    console.log(chalk.red(`Failed to reset sandbox: ${error.message}`));
+  }
+};
+
+const parseWriteCommand = (input) => {
+  const separator = '::';
+  const [left, ...rest] = input.split(separator);
+  if (!rest.length) {
+    return null;
+  }
+  const filePath = left.trim();
+  const promptText = rest.join(separator).trim();
+  if (!filePath || !promptText) {
+    return null;
+  }
+  return { filePath, promptText };
+};
+
+const sanitizePrompt = (promptText) => {
+  return promptText.replace(/```[\s\S]*?```/g, (match) => match.replace(/```/g, ''));
+};
+
+const runTestingLoop = async ({ filePath, originalPrompt, conversation, retries = 0 }) => {
+  if (retries >= MAX_SELF_HEAL_RETRIES) {
+    await logAudit(`Self-heal aborted for ${filePath} after ${retries} retries.`);
+    return;
+  }
+
+  const testResult = await testFile(filePath);
+  if (testResult.success) {
+    await logAudit(`Tests passed for ${filePath}.`);
+    if (testResult.output) {
+      console.log(chalk.green(testResult.output));
+    }
+    return;
+  }
+
+  console.log(chalk.red('Tests failed. Attempting self-heal...'));
+  await logAudit(`Tests failed for ${filePath}: ${testResult.error}`);
+
+  const healingPrompt = `The previous attempt to create ${filePath} failed tests with the following errors:\n${testResult.error}\nPlease provide a fixed version of the file.`;
+  const updatedConversation = [
+    ...conversation,
+    { role: 'user', content: `${originalPrompt}\n${healingPrompt}` }
+  ];
+
+  await writeStreamFile({
+    conversation: updatedConversation,
+    targetPath: filePath,
+    autoConfirm: true,
+    spinnerLabel: 'Healing file'
+  });
+
+  await runTestingLoop({ filePath, originalPrompt, conversation: updatedConversation, retries: retries + 1 });
+};
+
+const handleWrite = async ({ filePath, promptText, conversation }) => {
+  const safe = await writeStreamFile({
+    conversation: [
+      ...conversation,
+      {
+        role: 'system',
+        content: 'You are an AI that outputs code only when writing files.'
+      },
+      { role: 'user', content: promptText }
+    ],
+    targetPath: filePath,
+    autoConfirm: false,
+    spinnerLabel: 'Streaming code'
+  });
+
+  if (!safe) {
+    console.log(chalk.yellow('Write cancelled.'));
+    return;
+  }
+
+  await runTestingLoop({ filePath, originalPrompt: promptText, conversation });
+};
+
+const handleChat = async ({ promptText, conversation }) => {
+  const spinner = ora('Contacting Groq...').start();
+  try {
+    const response = await llm([
+      ...conversation,
+      { role: 'user', content: promptText }
+    ]);
+    spinner.stop();
+    console.log(chalk.green(response));
+    return response;
+  } catch (error) {
+    spinner.stop();
+    console.log(chalk.red(`Chat failed: ${error.message}`));
+    return null;
+  }
+};
+
+const handleRunCommand = async (command) => {
+  const [exe, ...args] = command.split(' ').filter(Boolean);
+  if (!exe) {
+    console.log(chalk.yellow('No command provided.'));
+    return;
+  }
+  const confirmed = await confirmAction(`Execute shell command: ${command}?`);
+  if (!confirmed) {
+    return;
+  }
+  const result = await runShell(exe, args);
+  if (result.success) {
+    console.log(chalk.green(result.output));
+  } else {
+    console.log(chalk.red(result.error));
+  }
+};
+
+const handleReadCommand = async (target) => {
+  const result = await readFile(target);
+  if (result.success) {
+    console.log(result.content);
+  } else {
+    console.log(chalk.red(result.error));
+  }
+};
+
+const main = async () => {
+  await ensureSandbox();
+  await logAudit('CLI session started.');
+  showHelp();
+
+  const conversation = [];
+
+  rl.prompt();
+
+  rl.on('line', async (line) => {
+    const input = line.trim();
+    if (!input) {
+      rl.prompt();
+      return;
+    }
+
+    if (input === ':exit') {
+      await logAudit('CLI session terminated by user.');
+      rl.close();
+      return;
+    }
+
+    if (input === ':help') {
+      showHelp();
+      rl.prompt();
+      return;
+    }
+
+    if (input.startsWith(':ls')) {
+      const target = input.replace(':ls', '').trim();
+      await listSandbox(target || '.');
+      rl.prompt();
+      return;
+    }
+
+    if (input === ':audit') {
+      await readAudit();
+      rl.prompt();
+      return;
+    }
+
+    if (input === ':reset') {
+      await resetSandbox();
+      rl.prompt();
+      return;
+    }
+
+    if (input.startsWith(':read')) {
+      const target = input.replace(':read', '').trim();
+      if (!target) {
+        console.log(chalk.yellow('Specify a file to read.'));
+      } else {
+        await handleReadCommand(target);
+      }
+      rl.prompt();
+      return;
+    }
+
+    if (input.startsWith(':run')) {
+      const command = input.replace(':run', '').trim();
+      await handleRunCommand(command);
+      rl.prompt();
+      return;
+    }
+
+    if (input.startsWith('write ')) {
+      const payload = input.replace('write ', '');
+      const parsed = parseWriteCommand(payload);
+      if (!parsed) {
+        console.log(chalk.red('Use format: write <file> :: <prompt>'));
+        rl.prompt();
+        return;
+      }
+      const promptText = sanitizePrompt(parsed.promptText);
+      await handleWrite({ filePath: parsed.filePath, promptText, conversation });
+      rl.prompt();
+      return;
+    }
+
+    if (input.startsWith('chat ')) {
+      const promptText = sanitizePrompt(input.replace('chat ', ''));
+      const answer = await handleChat({ promptText, conversation });
+      if (answer) {
+        conversation.push({ role: 'user', content: promptText });
+        conversation.push({ role: 'assistant', content: answer });
+      }
+      rl.prompt();
+      return;
+    }
+
+    console.log(chalk.yellow('Unknown command. Type :help for options.'));
+    rl.prompt();
+  });
+
+  rl.on('close', async () => {
+    console.log(chalk.cyan('Goodbye!'));
+    await logAudit('CLI session closed.');
+    process.exit(0);
+  });
+};
+
+main().catch(async (error) => {
+  console.error(chalk.red(`Fatal error: ${error.message}`));
+  await logAudit(`Fatal error: ${error.message}`);
+  process.exit(1);
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/server/**/__tests__/**/*.test.js'],
+  collectCoverageFrom: ['server/**/*.js', '!server/index.js']
+};

--- a/llm.js
+++ b/llm.js
@@ -1,0 +1,43 @@
+const axios = require('axios');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const callLLM = async (messages) => {
+  const apiKey = process.env.GROQ_API_KEY;
+  const model = process.env.MODEL || 'llama-3.1-8b-instant';
+  if (!apiKey) {
+    throw new Error('GROQ_API_KEY is not set.');
+  }
+
+  try {
+    const response = await axios.post(
+      'https://api.groq.com/openai/v1/chat/completions',
+      {
+        model,
+        messages,
+        temperature: 0.2,
+        stream: false
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        timeout: 15000
+      }
+    );
+
+    const { data } = response;
+    if (!data || !data.choices || !data.choices.length) {
+      throw new Error('Empty response from Groq.');
+    }
+    const choice = data.choices[0];
+    return choice.message && choice.message.content ? choice.message.content.trim() : '';
+  } catch (error) {
+    const message = error.response && error.response.data ? JSON.stringify(error.response.data) : error.message;
+    throw new Error(`Groq request failed: ${message}`);
+  }
+};
+
+module.exports = callLLM;

--- a/llmStream.js
+++ b/llmStream.js
@@ -1,0 +1,94 @@
+const fetch = require('node-fetch');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const streamLLM = async ({ messages, onToken }) => {
+  const apiKey = process.env.GROQ_API_KEY;
+  const model = process.env.MODEL || 'llama-3.1-8b-instant';
+
+  if (!apiKey) {
+    throw new Error('GROQ_API_KEY is not set.');
+  }
+
+  const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      temperature: 0.2,
+      stream: true
+    })
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Groq stream failed with status ${response.status}`);
+  }
+
+  let aggregated = '';
+  let buffer = '';
+
+  const iterator = response.body[Symbol.asyncIterator]();
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { value, done } = await iterator.next();
+    if (done) {
+      break;
+    }
+    buffer += value.toString();
+
+    const segments = buffer.split('\n\n');
+    buffer = segments.pop();
+
+    for (const segment of segments) {
+      if (!segment.trim()) {
+        continue;
+      }
+      const line = segment.trim();
+      if (!line.startsWith('data:')) {
+        continue;
+      }
+      const payload = line.replace('data:', '').trim();
+      if (payload === '[DONE]') {
+        buffer = '';
+        break;
+      }
+      try {
+        const json = JSON.parse(payload);
+        const delta = json.choices && json.choices[0] && json.choices[0].delta && json.choices[0].delta.content;
+        if (delta) {
+          aggregated += delta;
+          if (onToken) {
+            await onToken(delta);
+          }
+        }
+      } catch (error) {
+        buffer = `${payload}\n`;
+      }
+    }
+  }
+
+  if (buffer && buffer.trim() && buffer.trim() !== '[DONE]') {
+    try {
+      const json = JSON.parse(buffer.trim().replace(/^data:\s*/i, ''));
+      const delta = json.choices && json.choices[0] && json.choices[0].delta && json.choices[0].delta.content;
+      if (delta) {
+        aggregated += delta;
+        if (onToken) {
+          await onToken(delta);
+        }
+      }
+    } catch (error) {
+      // ignore trailing parse errors
+    }
+  }
+
+  return aggregated.trim();
+};
+
+module.exports = streamLLM;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "ai-terminal-agent",
+  "version": "1.0.0",
+  "description": "AI Terminal Agent CLI with MERN scaffold",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node server/index.js",
+    "dev": "concurrently \"npm:server\" \"npm:client\"",
+    "server": "nodemon server/index.js",
+    "client": "npm --prefix client run dev",
+    "test:server": "jest --runInBand --roots server",
+    "test:client": "npm --prefix client run test",
+    "lint": "eslint ."
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "axios": "^1.7.2",
+    "chalk": "^5.3.0",
+    "concurrently": "^8.2.2",
+    "dotenv": "^16.4.5",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "events": "^3.3.0",
+    "form-data": "^4.0.0",
+    "mongoose": "^8.4.4",
+    "node-fetch": "^2.6.9",
+    "ora": "^7.0.1",
+    "prompts": "^2.4.2"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-promise": "^6.1.1",
+    "jest": "^29.7.0",
+    "nodemon": "^3.1.0",
+    "supertest": "^6.4.2"
+  }
+}

--- a/server/__tests__/health.test.js
+++ b/server/__tests__/health.test.js
@@ -1,0 +1,11 @@
+const request = require('supertest');
+
+const app = require('../app');
+
+describe('Health endpoint', () => {
+  it('returns healthy status', async () => {
+    const response = await request(app).get('/api/health');
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('healthy');
+  });
+});

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const cors = require('cors');
+
+const healthRoutes = require('./routes/health.routes');
+
+const createApp = () => {
+  const app = express();
+  app.use(cors({ origin: '*' }));
+  app.use(express.json());
+
+  app.use('/api/health', healthRoutes);
+
+  app.get('/', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  app.use((error, _req, res, _next) => {
+    const status = error.status || 500;
+    res.status(status).json({ message: error.message || 'Internal server error' });
+  });
+
+  return app;
+};
+
+module.exports = createApp();

--- a/server/controllers/health.controller.js
+++ b/server/controllers/health.controller.js
@@ -1,0 +1,5 @@
+const getHealth = async (_req, res) => {
+  res.json({ status: 'healthy' });
+};
+
+module.exports = { getHealth };

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,28 @@
+const http = require('http');
+const dotenv = require('dotenv');
+
+const app = require('./app');
+const connectDatabase = require('./utils/database');
+
+dotenv.config();
+
+const startServer = () => {
+  const port = parseInt(process.env.PORT || '5000', 10);
+  const server = http.createServer(app);
+
+  server.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+
+  return server;
+};
+
+const bootstrap = async () => {
+  await connectDatabase();
+  startServer();
+};
+
+bootstrap().catch((error) => {
+  console.error(`Failed to start server: ${error.message}`);
+  process.exit(1);
+});

--- a/server/routes/health.routes.js
+++ b/server/routes/health.routes.js
@@ -1,0 +1,11 @@
+const { Router } = require('express');
+
+const { getHealth } = require('../controllers/health.controller');
+
+const createRouter = () => {
+  const router = Router();
+  router.get('/', getHealth);
+  return router;
+};
+
+module.exports = createRouter();

--- a/server/utils/database.js
+++ b/server/utils/database.js
@@ -1,0 +1,21 @@
+const mongoose = require('mongoose');
+
+const connectDatabase = async () => {
+  const uri = process.env.MONGO_URI;
+  if (!uri) {
+    console.warn('MONGO_URI not set. Skipping database connection.');
+    return;
+  }
+
+  if (mongoose.connection.readyState === 1) {
+    return;
+  }
+
+  await mongoose.connect(uri, {
+    serverSelectionTimeoutMS: 5000
+  });
+
+  console.log('Connected to MongoDB');
+};
+
+module.exports = connectDatabase;

--- a/tools/readFile.js
+++ b/tools/readFile.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const MAX_SIZE = 1024 * 1024; // 1MB
+
+const readFile = async (target) => {
+  try {
+    if (!target) {
+      throw new Error('No file specified.');
+    }
+    const sandbox = path.resolve(process.env.SANDBOX_DIR || './sandbox');
+    const resolved = path.resolve(sandbox, target);
+    if (!resolved.startsWith(sandbox)) {
+      throw new Error('Access outside sandbox denied.');
+    }
+    const stats = await fs.promises.stat(resolved);
+    if (stats.size > MAX_SIZE) {
+      throw new Error('File exceeds maximum readable size.');
+    }
+    const content = await fs.promises.readFile(resolved, 'utf8');
+    return { success: true, content };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+};
+
+module.exports = readFile;

--- a/tools/runShell.js
+++ b/tools/runShell.js
@@ -1,0 +1,66 @@
+const { spawn } = require('child_process');
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const ALLOW_CMDS = (process.env.ALLOW_CMDS || 'echo,ls,pwd,cat,npm,git').split(',').map((cmd) => cmd.trim());
+const DENY_CMDS = ['rm', 'sudo', 'curl', 'wget', 'shutdown', 'reboot'];
+
+const sanitizeArgs = (args) => {
+  const forbidden = [';', '&&', '||', '|'];
+  for (const token of forbidden) {
+    if (args.includes(token)) {
+      throw new Error('Command contains forbidden chaining operators.');
+    }
+  }
+};
+
+const runShell = async (command, args = []) => {
+  try {
+    if (!ALLOW_CMDS.includes(command)) {
+      return { success: false, error: `Command ${command} is not in allow list.` };
+    }
+    if (DENY_CMDS.includes(command)) {
+      return { success: false, error: `Command ${command} is denied.` };
+    }
+    sanitizeArgs(args.join(' '));
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: path.resolve(process.env.SANDBOX_DIR || './sandbox'),
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      resolve({ success: false, error: 'Command timed out.' });
+    }, 15000);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve({ success: true, output: stdout.trim() });
+      } else {
+        resolve({ success: false, error: stderr.trim() || `Command exited with code ${code}` });
+      }
+    });
+  });
+};
+
+module.exports = runShell;

--- a/tools/testFile.js
+++ b/tools/testFile.js
@@ -1,0 +1,74 @@
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const runProcess = ({ command, args, cwd, timeout = 10000 }) => {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      resolve({ success: false, error: 'Test command timed out.' });
+    }, timeout);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve({ success: true, output: stdout.trim() });
+      } else {
+        resolve({ success: false, error: stderr.trim() || `Exited with code ${code}` });
+      }
+    });
+  });
+};
+
+const testFile = async (relativePath) => {
+  try {
+    const sandbox = path.resolve(process.env.SANDBOX_DIR || './sandbox');
+    const resolved = path.resolve(sandbox, relativePath);
+    if (!resolved.startsWith(sandbox)) {
+      throw new Error('Testing outside sandbox is forbidden.');
+    }
+
+    const packagePath = path.join(sandbox, 'package.json');
+    if (fs.existsSync(packagePath)) {
+      return await runProcess({
+        command: 'npm',
+        args: ['test', '--', '--runInBand'],
+        cwd: sandbox
+      });
+    }
+
+    if (resolved.endsWith('.js')) {
+      return await runProcess({
+        command: 'node',
+        args: [resolved],
+        cwd: sandbox
+      });
+    }
+
+    return { success: true, output: 'No tests executed (unsupported file type).' };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+};
+
+module.exports = testFile;

--- a/tools/writeFile.js
+++ b/tools/writeFile.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const path = require('path');
+const prompts = require('prompts');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const MAX_FILES = 50;
+const MAX_SIZE = 1024 * 1024;
+
+const countFiles = async (dir) => {
+  const entries = await fs.promises.readdir(dir);
+  let count = 0;
+  for (const entry of entries) {
+    const target = path.join(dir, entry);
+    const stats = await fs.promises.stat(target);
+    if (stats.isDirectory()) {
+      count += await countFiles(target);
+    } else {
+      count += 1;
+    }
+  }
+  return count;
+};
+
+const confirmOverwrite = async ({ autoConfirm, message }) => {
+  if (autoConfirm) {
+    return true;
+  }
+  const { value } = await prompts({
+    type: 'confirm',
+    name: 'value',
+    message,
+    initial: false
+  });
+  return Boolean(value);
+};
+
+const safeWriteFile = async ({ targetPath, content, autoConfirm = false }) => {
+  try {
+    const sandbox = path.resolve(process.env.SANDBOX_DIR || './sandbox');
+    const resolved = path.resolve(sandbox, targetPath);
+    if (!resolved.startsWith(sandbox)) {
+      throw new Error('Attempted write outside sandbox.');
+    }
+
+    await fs.promises.mkdir(path.dirname(resolved), { recursive: true });
+
+    const fileCount = await countFiles(sandbox);
+    if (fileCount >= MAX_FILES) {
+      throw new Error('Sandbox file quota exceeded.');
+    }
+
+    if (Buffer.byteLength(content, 'utf8') > MAX_SIZE) {
+      throw new Error('File exceeds maximum allowed size.');
+    }
+
+    let target = resolved;
+    if (fs.existsSync(resolved)) {
+      const confirmed = await confirmOverwrite({ autoConfirm, message: `Overwrite ${targetPath}?` });
+      if (!confirmed) {
+        return { success: false, error: 'User declined overwrite.' };
+      }
+    }
+
+    const tempPath = `${resolved}.tmp-${Date.now()}`;
+    await fs.promises.writeFile(tempPath, content, 'utf8');
+    await fs.promises.rename(tempPath, target);
+
+    return { success: true, path: target };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+};
+
+module.exports = safeWriteFile;

--- a/tools/writeStreamFile.js
+++ b/tools/writeStreamFile.js
@@ -1,0 +1,116 @@
+const fs = require('fs');
+const path = require('path');
+const prompts = require('prompts');
+const chalk = require('chalk');
+const dotenv = require('dotenv');
+
+const llmStream = require('../llmStream');
+
+dotenv.config();
+
+const MAX_FILES = 50;
+const MAX_SIZE = 1024 * 1024;
+
+const logAudit = async (message) => {
+  const line = `[${new Date().toISOString()}] ${message}\n`;
+  await fs.promises.appendFile(path.resolve('audit.log'), line).catch(() => {});
+};
+
+const countFiles = async (dir) => {
+  const entries = await fs.promises.readdir(dir);
+  let count = 0;
+  for (const entry of entries) {
+    const target = path.join(dir, entry);
+    const stats = await fs.promises.stat(target);
+    if (stats.isDirectory()) {
+      count += await countFiles(target);
+    } else {
+      count += 1;
+    }
+  }
+  return count;
+};
+
+const confirmOverwrite = async ({ autoConfirm, message }) => {
+  if (autoConfirm) {
+    return true;
+  }
+  const { value } = await prompts({
+    type: 'confirm',
+    name: 'value',
+    message,
+    initial: false
+  });
+  return Boolean(value);
+};
+
+const sanitizeChunk = (chunk) => {
+  return chunk.replace(/```/g, '');
+};
+
+const writeStreamFile = async ({ conversation, targetPath, autoConfirm = false, spinnerLabel = 'Streaming' }) => {
+  const sandbox = path.resolve(process.env.SANDBOX_DIR || './sandbox');
+  const resolved = path.resolve(sandbox, targetPath);
+
+  if (!resolved.startsWith(sandbox)) {
+    console.log(chalk.red('Write path outside sandbox.'));
+    return false;
+  }
+
+  await fs.promises.mkdir(path.dirname(resolved), { recursive: true });
+
+  const fileCount = await countFiles(sandbox);
+  if (fileCount >= MAX_FILES && !fs.existsSync(resolved)) {
+    console.log(chalk.red('Sandbox file quota exceeded.'));
+    return false;
+  }
+
+  if (fs.existsSync(resolved)) {
+    const confirmed = await confirmOverwrite({ autoConfirm, message: `Overwrite ${targetPath}?` });
+    if (!confirmed) {
+      await logAudit(`WRITE_ABORTED ${targetPath}`);
+      return false;
+    }
+  }
+
+  const tempPath = `${resolved}.tmp-${Date.now()}`;
+  const stream = fs.createWriteStream(tempPath, { encoding: 'utf8' });
+
+  let totalBytes = 0;
+  let failed = false;
+
+  const writeToken = async (token) => {
+    const cleaned = sanitizeChunk(token);
+    totalBytes += Buffer.byteLength(cleaned, 'utf8');
+    if (totalBytes > MAX_SIZE) {
+      failed = true;
+      throw new Error('Stream exceeded maximum file size.');
+    }
+    process.stdout.write(cleaned);
+    stream.write(cleaned);
+  };
+
+  try {
+    await logAudit(`WRITE_STREAM_START ${targetPath}`);
+    await llmStream({
+      messages: conversation,
+      onToken: writeToken
+    });
+    stream.end();
+    if (failed) {
+      throw new Error('Stream failed due to quota.');
+    }
+    await fs.promises.rename(tempPath, resolved);
+    await logAudit(`WRITE_STREAM_SUCCESS ${targetPath}`);
+    console.log(`\n${chalk.green(`${spinnerLabel} complete.`)}`);
+    return true;
+  } catch (error) {
+    stream.destroy();
+    await fs.promises.rm(tempPath, { force: true }).catch(() => {});
+    await logAudit(`WRITE_STREAM_FAIL ${targetPath}: ${error.message}`);
+    console.log(`\n${chalk.red(`Stream failed: ${error.message}`)}`);
+    return false;
+  }
+};
+
+module.exports = writeStreamFile;


### PR DESCRIPTION
## Summary
- implement AI Terminal Agent CLI with Groq integration, sandbox file streaming, auditing, and self-healing workflow
- add secure toolset for sandboxed file, command, and testing operations
- scaffold Express/Mongoose API layer and Vite/React client with React Query-driven content

## Testing
- npm install *(fails: registry access forbidden in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97de6a7608330b86c04ccb4077152